### PR TITLE
Configured express-session with connect-mongo

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -10,6 +10,7 @@ router.get('/', (req, res) => {
 
 router.get('/home', (req, res) => {
   if (req.isAuthenticated()) {
+    console.log(req.user.name, 'is logged in.')    
     res.sendFile(path.join(__dirname, 'home.html'));
   } else {
     res.redirect('/');

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-2": "^6.11.0",
     "body-parser": "^1.15.2",
+    "connect-mongo": "^1.3.2",
     "cors": "^2.7.1",
     "dotenv": "^4.0.0",
     "express": "^4.14.0",


### PR DESCRIPTION
We use express-session to store server-side user sessions, but the default session store (where it stores the data) is not supposed to be used in production, so I added connect-mongo as our session store. Also:

- Put in some recommended options for express-session relating to when to update the session
- Put a console.log in the /home route to test accessing user info from the session store