### PR TITLE
Use native promises instead of mpromise

### DIFF
--- a/server/_config.js
+++ b/server/_config.js
@@ -1,8 +1,6 @@
 import express from 'express';
 import mongoose from 'mongoose';
-import session from 'express-session';
 
-const MongoStore = require('connect-mongo')(session);
 const app = express();
 
 const config = {};
@@ -25,4 +23,4 @@ mongoose.connect(config.mongoURI[app.settings.env], (err, res) => {
 // set mongoose promises to es6 default
 mongoose.Promise = global.Promise;
 
-export { app, MongoStore, mongoose };
+export { app, mongoose };

--- a/server/_config.js
+++ b/server/_config.js
@@ -1,3 +1,10 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import session from 'express-session';
+
+const MongoStore = require('connect-mongo')(session);
+const app = express();
+
 const config = {};
 
 config.mongoURI = {
@@ -5,4 +12,17 @@ config.mongoURI = {
   test: 'mongodb://localhost/notist-test',
 };
 
-module.exports = config;
+// DB Setup
+// *** mongoose *** ///
+mongoose.connect(config.mongoURI[app.settings.env], (err, res) => {
+  if (err) {
+    console.log(`Error connecting to the database: ${err}`);
+  } else {
+    console.log(`Connected to Database: ${config.mongoURI[app.settings.env]}`);
+  }
+});
+
+// set mongoose promises to es6 default
+mongoose.Promise = global.Promise;
+
+export { app, MongoStore, mongoose };

--- a/server/app.js
+++ b/server/app.js
@@ -1,32 +1,13 @@
-import express from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors';
-import mongoose from 'mongoose';
 import passport from 'passport';
 import session from 'express-session';
 import router from './router';
 import authInit from './authentication';
-import config from './_config'; // *** config file *** //
-
-const MongoStore = require('connect-mongo')(session);
-const app = express();
-module.exports.app = app;
+import { app, MongoStore, mongoose } from './_config'; // *** config file *** //
 
 // load environment variables
 require('dotenv').load();
-
-// DB Setup
-// *** mongoose *** ///
-mongoose.connect(config.mongoURI[app.settings.env], function (err, res) {
-  if (err) {
-    console.log('Error connecting to the database. ' + err);
-  } else {
-    console.log('Connected to Database: ' + config.mongoURI[app.settings.env]);
-  }
-});
-
-// set mongoose promises to es6 default
-mongoose.Promise = global.Promise;
 
 // passport google oauth initialization
 app.use(session({

--- a/server/app.js
+++ b/server/app.js
@@ -1,10 +1,12 @@
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import passport from 'passport';
-import session from 'express-session';
 import router from './router';
 import authInit from './authentication';
-import { app, MongoStore, mongoose } from './_config'; // *** config file *** //
+import { app, mongoose } from './_config'; // *** config file *** //
+import session from 'express-session';
+
+const MongoStore = require('connect-mongo')(session);
 
 // load environment variables
 require('dotenv').load();

--- a/server/models/annotation.js
+++ b/server/models/annotation.js
@@ -1,4 +1,5 @@
-import mongoose, { Schema } from 'mongoose';
+import { mongoose } from '../_config';
+import { Schema } from 'mongoose';
 
 const ObjectId = Schema.Types.ObjectId;
 

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -1,4 +1,5 @@
-import mongoose, { Schema } from 'mongoose';
+import { mongoose } from '../_config';
+import { Schema } from 'mongoose';
 
 // TODO: Add field to keep track of number of users who have commented, number of comments
 

--- a/server/models/group.js
+++ b/server/models/group.js
@@ -1,4 +1,5 @@
-import mongoose, { Schema } from 'mongoose';
+import { mongoose } from '../_config';
+import { Schema } from 'mongoose';
 
 const ObjectId = Schema.Types.ObjectId;
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,4 +1,5 @@
-import mongoose, { Schema } from 'mongoose';
+import { mongoose } from '../_config';
+import { Schema } from 'mongoose';
 
 const userSchema = new Schema({
   // TODO: Some of these need to be required fields


### PR DESCRIPTION
I changed some things so I think we won't get the annoying warning about using the wrong promises library. Basically, re-exporting mongoose after modifying mongoose.Promise. It's a little ugly though so feel free to criticize. I pulled more things into _config.js to avoid circular dependencies.