### PR TITLE
highlight ranges

### DIFF
--- a/server/controllers/annotation_controller.js
+++ b/server/controllers/annotation_controller.js
@@ -46,6 +46,7 @@ export const createAnnotation = (user, body, articleId) => {
       });
   } else {
     annotation.articleText = body.articleText;
+    annotation.ranges = body.ranges;
     annotation.parent = null;
     annotation.article = articleId;
     annotation.isPublic = body.isPublic;

--- a/server/models/annotation.js
+++ b/server/models/annotation.js
@@ -3,6 +3,14 @@ mongoose.Promise = global.Promise;
 
 const ObjectId = Schema.Types.ObjectId;
 
+// sub-schema for "ranges" entries
+const rangeSchema = new Schema({
+  start: String,
+  end: String,
+  startOffset: Number,
+  endOffset: Number,
+}, { _id: false });
+
 // TODO: change names of fields to not have "Id" in them
 const annotationSchema = new Schema({
   author: { type: ObjectId, ref: 'User' },
@@ -15,7 +23,7 @@ const annotationSchema = new Schema({
 
   text: { type: String, trim: true },
   articleText: String,
-  ranges: { type: Array, default: [] },
+  ranges: [rangeSchema],
   // TODO: implement system for locating article text robustly
   points: { type: Number, default: 0 },
 

--- a/server/models/annotation.js
+++ b/server/models/annotation.js
@@ -15,6 +15,12 @@ const annotationSchema = new Schema({
 
   text: { type: String, trim: true },
   articleText: String,
+  ranges: [{
+    start: String,
+    startOffset: Number,
+    end: String,
+    endOffset: Number,
+  }],
   // TODO: implement system for locating article text robustly
   points: { type: Number, default: 0 },
 

--- a/server/models/annotation.js
+++ b/server/models/annotation.js
@@ -15,12 +15,7 @@ const annotationSchema = new Schema({
 
   text: { type: String, trim: true },
   articleText: String,
-  ranges: [{
-    start: String,
-    startOffset: Number,
-    end: String,
-    endOffset: Number,
-  }],
+  ranges: { type: Array, default: [] },
   // TODO: implement system for locating article text robustly
   points: { type: Number, default: 0 },
 

--- a/test/test-annotation.js
+++ b/test/test-annotation.js
@@ -71,6 +71,12 @@ describe('Annotations', function () {
       const articleText = 'This is a new article';
       const text = 'This is my annotation';
       const isPublic = true;
+      const ranges = [{
+        end: '/div[2]/section[1]/div[1]/div[1]/div[2]/div[1]/p[1]',
+        endOffset: 64,
+        start: '/div[2]/section[1]/div[1]/div[1]/div[2]/div[1]/p[1]',
+        startOffset: 50,
+      }];
       passportStub.login(user);
       chai.request(app)
       .post('/api/annotation')
@@ -78,6 +84,7 @@ describe('Annotations', function () {
         uri,
         groups: [],
         articleText,
+        ranges,
         text,
         isPublic,
         parentId: null,
@@ -86,6 +93,7 @@ describe('Annotations', function () {
         res.should.have.status(200);
         res.body.should.have.property('SUCCESS');
         res.body.SUCCESS.articleText.should.equal(articleText);
+        res.body.SUCCESS.ranges.should.eql(ranges);
         res.body.SUCCESS.text.should.equal(text);
         res.body.SUCCESS.isPublic.should.be.true;
       });
@@ -101,6 +109,12 @@ describe('Annotations', function () {
       const articleText = 'This is another article';
       const text = 'This is annotationA for articleA';
       const isPublic = false;
+      const ranges = [{
+        end: '/p[69]/span/span',
+        endOffset: 120,
+        start: '/p[70]/span/span',
+        startOffset: 0,
+      }];
       passportStub.login(user);
       chai.request(app)
       .post('/api/annotation')
@@ -108,6 +122,7 @@ describe('Annotations', function () {
         uri: ArticleA.uri,
         groups: [GroupA.id],
         articleText,
+        ranges,
         text,
         isPublic,
         parentId: null,
@@ -116,6 +131,7 @@ describe('Annotations', function () {
         res.should.have.status(200);
         res.body.should.have.property('SUCCESS');
         res.body.SUCCESS.articleText.should.equal(articleText);
+        res.body.SUCCESS.ranges.should.eql(ranges);
         res.body.SUCCESS.text.should.equal(text);
       });
 
@@ -128,6 +144,12 @@ describe('Annotations', function () {
       const articleText = 'ArticleA is more interesting than ArticleB';
       const text = 'This is annotationB for articleA';
       const isPublic = true;
+      const ranges = [{
+        end: '/p[69]/span/span',
+        endOffset: 12,
+        start: '/p[70]/span/span',
+        startOffset: 1,
+      }];
       passportStub.login(user);
       chai.request(app)
       .post('/api/annotation')
@@ -135,6 +157,7 @@ describe('Annotations', function () {
         uri: ArticleA.uri,
         groups: [GroupA.id],
         articleText,
+        ranges,
         text,
         isPublic,
       })
@@ -142,6 +165,7 @@ describe('Annotations', function () {
         res.should.have.status(200);
         res.body.should.have.property('SUCCESS');
         res.body.SUCCESS.articleText.should.equal(articleText);
+        res.body.SUCCESS.ranges.should.eql(ranges);
         res.body.SUCCESS.text.should.equal(text);
       }); // INSTEAD OF DONE, we should make sure its in db ?
 


### PR DESCRIPTION
## Why
These changes allow for highlighting article annotations in the browser extension - see https://github.com/Notist/browser-extension/pull/5 which implements highlighting. Annotation objects must keep track of the selected DOM that corresponds the annotation's articleText. This way, we know which parts of the DOM to highlight on the frontend.
This PR makes each annotation store a `ranges` field, which indicates which part of the article's DOM to highlight in order to highlight the an annotation's article text.
e.g. A ranges field might look like this:
```
  ranges: [
    {
      start: "/p[69]/span/span",           # to start element
      end: "/p[70]/span/span",             # end element
      startOffset: 0,                      # character offset within start element
      endOffset: 120                       # character offset within end element
    }
  ]
```
And, on the frontend, we highlight the ranges to make the article text appear highlighted.

## Changes
- Added a `ranges` field to the `Annotation` schema
- Changed the `createAnnotation` method to accept the range field for top-level annotations

