### PR TITLE
Endpoint for retrieving user info

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -91,7 +91,15 @@ router.post('/api/article', (req, res) => {
 
 router.get('/api/user', (req, res) => {
   if (req.isAuthenticated()) {
-    res.json(req.user);
+    // populate the user's groups
+    req.user.populate('groups')
+    .execPopulate()
+    .then(user => {
+      res.json(user);
+    })
+    .catch(err => {
+      res.json({ ERROR: serializeError(err) });
+    });
   } else {
     res.status(401).end();
   }

--- a/server/router.js
+++ b/server/router.js
@@ -89,10 +89,13 @@ router.post('/api/article', (req, res) => {
   }
 });
 
-// TODO: Decide what to do with users
-router.route('/api/user')
-//      .post(Users.createUser)
-      .get(Users.getUsers);
+router.get('/api/user', (req, res) => {
+  if (req.isAuthenticated()) {
+    res.json(req.user);
+  } else {
+    res.status(401).end();
+  }
+});
 
 /*
 Create a new group.

--- a/test/test-user.js
+++ b/test/test-user.js
@@ -1,0 +1,106 @@
+import { app } from '../server/app';
+app.settings.env = 'test';
+
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import chaiAsPromised from 'chai-as-promised';
+import passportStub from 'passport-stub';
+
+import Group from '../server/models/group';
+import User from '../server/models/user';
+
+import util from './util';
+
+const should = chai.should();
+chai.use(chaiHttp);
+chai.use(chaiAsPromised);
+passportStub.install(app);
+// eslint comment:
+/* global describe it before after afterEach:true */
+
+describe('Users', function () {
+  let user0 = null; // in neither group
+  let user1 = null; // in both groups
+
+  before(function () {
+    return Promise.all([
+      util.addUser('user0'),
+      util.addUserWithNGroups(2, 'user1'),
+    ])
+    .then(results => {
+      user0 = results[0];
+      user1 = results[1].user;
+    });
+  });
+
+  after(function () {
+    passportStub.logout();
+    return Promise.all([
+      User.collection.drop(),
+      Group.collection.drop(),
+    ]);
+  });
+
+  afterEach(function () {
+    passportStub.logout();
+  });
+
+  // unit tests
+  describe('User controller', function () {});
+
+  describe('API calls', function () {
+    describe('GET /api/user', function () {
+      it('should return 401 error for unauthenticated user', function (done) {
+        // not logged in
+        chai.request(app)
+          .get('/api/user')
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(401);
+            done();
+          });
+      });
+
+      it('should return user object when authenticated', function (done) {
+        passportStub.login(user0);
+        chai.request(app)
+          .get('/api/user')
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(200);
+            res.body.should.have.property('username', 'user0');
+            res.body.should.have.property('email', 'user0@testuri.com');
+            res.body.should.have.property('name', 'Test User \'user0\'');
+            res.body.should.have.property('googleId', 'test_user0');
+            res.body.should.have.property('groups').that.is.empty;
+            done();
+          });
+      });
+
+      it('should populate groups field when authenticated user is in groups', function (done) {
+        passportStub.login(user1);
+        chai.request(app)
+          .get('/api/user')
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(200);
+            res.body.should.have.property('username', 'user1');
+            res.body.should.have.property('email', 'user1@testuri.com');
+            res.body.should.have.property('name', 'Test User \'user1\'');
+            res.body.should.have.property('googleId', 'test_user1');
+
+            res.body.should.have.property('groups').with.lengthOf(2);
+            console.log(res.body.groups);
+            res.body.groups[0].id.should.not.equal(res.body.groups[1].id);
+            for (let i = 0; i < 2; i++) {
+              const group = res.body.groups[i];
+              group.name.should.match(/Group [1-2]/);
+              group.description.should.equal(`Description of ${group.name}`);
+              group.creator.toString().should.equal(user1.id);
+            }
+            done();
+          });
+      });
+    });
+  });
+});

--- a/test/test-user.js
+++ b/test/test-user.js
@@ -90,7 +90,6 @@ describe('Users', function () {
             res.body.should.have.property('googleId', 'test_user1');
 
             res.body.should.have.property('groups').with.lengthOf(2);
-            console.log(res.body.groups);
             res.body.groups[0].id.should.not.equal(res.body.groups[1].id);
             for (let i = 0; i < 2; i++) {
               const group = res.body.groups[i];

--- a/test/test-user.js
+++ b/test/test-user.js
@@ -90,10 +90,10 @@ describe('Users', function () {
             res.body.should.have.property('googleId', 'test_user1');
 
             res.body.should.have.property('groups').with.lengthOf(2);
-            res.body.groups[0].id.should.not.equal(res.body.groups[1].id);
+            res.body.groups[0]._id.toString().should.not.equal(res.body.groups[1]._id.toString());
             for (let i = 0; i < 2; i++) {
               const group = res.body.groups[i];
-              group.name.should.match(/Group [1-2]/);
+              group.name.should.match(/Group [0-1]/);
               group.description.should.equal(`Description of ${group.name}`);
               group.creator.toString().should.equal(user1.id);
             }

--- a/test/util.js
+++ b/test/util.js
@@ -41,7 +41,7 @@ exports.addUserWithNGroups = function (nGroups, username = 'user', groupName = '
   }
 
   return Promise.all(groups.map(group => { return group.save(); }))
-  .then((savedGroups) => {
+  .then(savedGroups => {
     user.groups = savedGroups.map(group => {
       return {
         _id: group._id,


### PR DESCRIPTION
Small change. In the browser-extension, we don't have access to the passport session and thus cannot load the user's information (groupIds, username, etc.). We send a request from the browser-extension to the `api/user` endpoint in this PR to load the user's information.