### PR TITLE
Ethan/no denormalize

### DIFF
--- a/server/authentication.js
+++ b/server/authentication.js
@@ -14,7 +14,7 @@ const authCallback = (accessToken, refreshToken, profile, done) => {
         myUser = new User({
           name: profile.displayName,
           email: profile.emails[0].value,
-          groupIds: [],
+          groups: [],
           // TODO: let user specify username
           username: `${profile.name.givenName}${profile.id}`,
         });

--- a/server/controllers/annotation_controller.js
+++ b/server/controllers/annotation_controller.js
@@ -1,5 +1,4 @@
 import Annotation from '../models/annotation';
-import mongodb from 'mongodb';
 
 // direct access to a specific annotation
 export const getAnnotation = (user, annotationId) => {
@@ -69,11 +68,11 @@ export const createAnnotation = (user, body, articleId) => {
 // Also succeeds if user is null and comment thread is public.
 // Returns a promise.
 export const getReplies = (user, parentId) => {
-  const conditions = { ancestors: { $in: [new mongodb.ObjectId(parentId)] } }; // TODO: I hate this whole objectId thing
+  const conditions = { parent: parentId };
   if (user === null) {
     conditions.isPublic = true;
   } else {
-    conditions.$or = [{ groupIds: { $in: user.groupIds } }, { isPublic: true }];
+    conditions.$or = [{ groups: { $in: user.groups } }, { isPublic: true }];
   }
   return Annotation.find(conditions);
 };

--- a/server/controllers/article_controller.js
+++ b/server/controllers/article_controller.js
@@ -38,8 +38,7 @@ export const getArticleAnnotations = (user, uri, toplevelOnly) => {
   if (user === null) {
     conditions.isPublic = true;
   } else {
-    const groupIds = user.groups.map(group => { return group._id; });
-    conditions.$or = [{ groups: { $in: groupIds } },
+    conditions.$or = [{ groups: { $in: user.groups } },
                       { isPublic: true },
                       { author: user._id }];
   }

--- a/server/controllers/user_controller.js
+++ b/server/controllers/user_controller.js
@@ -21,11 +21,10 @@ export const getUsers = (req, res) => {
   res.send('getting users');
 };
 
-export const addUserGroups = (userId, groups) => {
-  const groupObjs = groups.map(group => { return { _id: group._id, name: group.name, isPersonal: group.isPersonal }; });
-  return User.findByIdAndUpdate(userId, { $addToSet: { groups: { $each: groupObjs } } });
+export const addUserGroups = (userId, groupIds) => {
+  return User.findByIdAndUpdate(userId, { $addToSet: { groups: { $each: groupIds } } }, { new: true });
 };
 
-export const addUserGroup = (userId, group) => {
-  return addUserGroups(userId, [group]);
+export const addUserGroup = (userId, groupId) => {
+  return addUserGroups(userId, [groupId]);
 };

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -9,13 +9,9 @@ const userSchema = new Schema({
   name: { type: String, required: true },
   username: { type: String, unique: true, required: true },
   email: { type: String, unique: true, required: true },
-  groups: [{ _id: { type: Schema.Types.ObjectId, ref: 'Group' },
-             name: String,
-             isPersonal: Boolean }],
-  usersIFollow: [{ _id: { type: Schema.Types.ObjectId, ref: 'User' },
-                   username: String }],
-  usersFollowingMe: [{ _id: { type: Schema.Types.ObjectId, ref: 'User' },
-                      username: String }],
+  groups: [{ type: Schema.Types.ObjectId, ref: 'Group' }],
+  usersIFollow: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+  usersFollowingMe: [{ type: Schema.Types.ObjectId, ref: 'User' }],
 });
 
 userSchema.methods.isMemberOf = function isMemberOf(groupIdIn) {
@@ -24,7 +20,7 @@ userSchema.methods.isMemberOf = function isMemberOf(groupIdIn) {
     groupId = new mongodb.ObjectId(groupIdIn);
   }
   return this.groups.some(someGroup => {
-    return someGroup._id.equals(groupId);
+    return someGroup.equals(groupId);
   });
 };
 

--- a/server/router.js
+++ b/server/router.js
@@ -165,9 +165,12 @@ router.post('/api/group/:groupId/user/:userId', (req, res) => {
   const groupId = req.params.groupId;
   const userId = req.params.userId;
   if (req.isAuthenticated() && req.user.isMemberOf(groupId)) {
-    Groups.addGroupMember(groupId, userId)
-    .then(result => {
-      res.json({ SUCCESS: result });
+    Users.addUserGroup(userId, groupId)
+    .then(updatedUser => {
+      return Groups.addGroupMember(groupId, userId);
+    })
+    .then(updatedGroup => {
+      res.json({ SUCCESS: updatedGroup });
     })
     .catch(err => {
       res.json({ ERROR: serializeError(err) });

--- a/server/router.js
+++ b/server/router.js
@@ -109,7 +109,7 @@ router.post('/api/group', (req, res) => {
     const isPublic = !isPersonal && (req.body.isPublic || false);
     Groups.createGroup(req.body.name, req.body.description, req.user._id, isPersonal, isPublic)
     .then(createdGroup => {
-      return Users.addUserGroup(req.user._id, createdGroup._id)
+      Users.addUserGroup(req.user._id, createdGroup._id)
       .then(updateResult => {
         res.json({ SUCCESS: createdGroup });
       });

--- a/server/router.js
+++ b/server/router.js
@@ -109,7 +109,7 @@ router.post('/api/group', (req, res) => {
     const isPublic = !isPersonal && (req.body.isPublic || false);
     Groups.createGroup(req.body.name, req.body.description, req.user._id, isPersonal, isPublic)
     .then(createdGroup => {
-      Users.addUserGroup(req.user._id, createdGroup)
+      return Users.addUserGroup(req.user._id, createdGroup._id)
       .then(updateResult => {
         res.json({ SUCCESS: createdGroup });
       });


### PR DESCRIPTION
Changes the user model to no longer use any denormalization, since getting fields of referenced objects can be handled more flexibly by Mongoose's `populate`, and having denormalized fields makes `populate` hard to use.

Also, a couple other bug fixes I encountered when checking things over.