### PR TITLE
redirect to frontend login page and feed page

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -38,12 +38,14 @@ app.use(session({
 app.use(passport.initialize());
 app.use(passport.session());
 authInit(passport);
+
+const frontEndHost = process.env.NODE_ENV === 'production' ? 'http://notist-frontend.herokuapp.com' : 'http://localhost:5000';
 app.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
-app.get('/auth/google/callback', passport.authenticate('google', { successRedirect: '/', failureRedirect: '/login' }));
+app.get('/auth/google/callback', passport.authenticate('google', { successRedirect: frontEndHost, failureRedirect: `${frontEndHost}/login` }));
 app.get('/login/facebook', passport.authenticate('facebook', { scope: ['email'] }));
 app.get('/auth/facebook/callback',
-  passport.authenticate('facebook', { successRedirect: '/',
-                                      failureRedirect: '/login' }));
+  passport.authenticate('facebook', { successRedirect: frontEndHost,
+                                      failureRedirect: `${frontEndHost}/login` }));
 
 // enable/disable cross origin resource sharing if necessary
 app.use(cors());

--- a/server/home.html
+++ b/server/home.html
@@ -1,2 +1,0 @@
-You are logged in <br/>
-<a href="/logout">logout</a>

--- a/server/login.html
+++ b/server/login.html
@@ -1,7 +1,0 @@
-<html>
-  <body>
-    <a href="/auth/google">Login with Google</a>
-    <br>
-    <a href="/login/facebook">Login with Facebook</a>
-  </body>
-</html>

--- a/server/router.js
+++ b/server/router.js
@@ -20,25 +20,6 @@ const router = Router();
   DELETE -> {success}
 */
 
-// navigate to login page
-router.get('/login', (req, res) => {
-  if (req.isAuthenticated()) {
-    res.redirect('/');
-  } else {
-    res.sendFile(path.join(__dirname, 'login.html'));
-  }
-});
-
-// navigate to home page
-router.get('/', (req, res) => {
-  if (req.isAuthenticated()) {
-    console.log(req.user.name, 'is logged in.');
-    res.sendFile(path.join(__dirname, 'home.html'));
-  } else {
-    res.redirect('/login');
-  }
-});
-
 // navigate to logout page
 router.get('/logout', (req, res) => {
   req.logout();


### PR DESCRIPTION
Rather than serving the login page from the API, we serve it from the frontend server, at [frontend-host]/login - https://github.com/Notist/front-end/pull/6
Changes:
- have the passport success and failure redirects go to the frontend feed view and login page respectively
- deleted the now unnecessary login.html and home.html pages and removed the routes that served them