### PR TITLE
Set cors options to allow requests from frontend

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -10,6 +10,8 @@ import session from 'express-session';
 
 const MongoStore = require('connect-mongo')(session);
 
+const frontEndHost = process.env.NODE_ENV === 'production' ? 'http://notist-frontend.herokuapp.com' : 'http://localhost:5000';
+
 const app = express();
 module.exports.app = app;
 
@@ -39,7 +41,6 @@ app.use(passport.initialize());
 app.use(passport.session());
 authInit(passport);
 
-const frontEndHost = process.env.NODE_ENV === 'production' ? 'http://notist-frontend.herokuapp.com' : 'http://localhost:5000';
 app.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
 app.get('/auth/google/callback', passport.authenticate('google', { successRedirect: frontEndHost, failureRedirect: `${frontEndHost}/login` }));
 app.get('/login/facebook', passport.authenticate('facebook', { scope: ['email'] }));
@@ -48,7 +49,11 @@ app.get('/auth/facebook/callback',
                                       failureRedirect: `${frontEndHost}/login` }));
 
 // enable/disable cross origin resource sharing if necessary
-app.use(cors());
+const corsOptions = {
+  origin: frontEndHost,
+  credentials: true,
+};
+app.use(cors(corsOptions));
 
 // enable json message body for posting data to API
 app.use(bodyParser.urlencoded({ extended: true }));


### PR DESCRIPTION
We won't be able to send requests from the frontend unless the server sets these CORS options. I was getting an error when trying to send a request from the frontend, but it went away after I set these options.

This is because we send credentialed (with user cookies) cross-origin requests from the frontend.

From [the CORS docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests):
`When responding to a credentialed request, the server must specify an origin in the value of the Access-Control-Allow-Origin header, instead of specifying the "*" wildcard.
Because the request headers in the above example include a Cookie header, the request would fail if the value of the Access-Control-Allow-Origin header were "*". But it does not fail: Because the value of the Access-Control-Allow-Origin header is "http://foo.example" (an actual origin) rather than the "*" wildcard, the credential-cognizant content is returned to the invoking web content.`
