### PR TITLE
Azhu/top annotations

### DIFF
--- a/server/controllers/article_controller.js
+++ b/server/controllers/article_controller.js
@@ -51,7 +51,7 @@ export const addArticleAnnotation = (articleId, annotationId) => {
 // If user is null, return public annotations.
 // Returns a promise.
 
-export const getArticleAnnotations = (user, uri, toplevelOnly) => {
+export const getArticleAnnotations = (user, uri, topLevelOnly) => {
   const conditions = {};
   if (user === null) {
     conditions.isPublic = true;
@@ -60,19 +60,26 @@ export const getArticleAnnotations = (user, uri, toplevelOnly) => {
                       { isPublic: true },
                       { author: user._id }];
   }
-  if (typeof toplevelOnly !== 'undefined' && toplevelOnly) {
-    conditions.isTopLevel = true;
-  }
-  return getArticle(uri)
-  .deepPopulate(['annotations.childAnnotations.childAnnotations.childAnnotations.childAnnotations.childAnnotations.childAnnotations'])
-  .then((article) => {
-    if (article === null) {
-      // article not in db, so there are no annotations
-      return [];
-    } else {
+  if (topLevelOnly) {
+    return getArticle(uri)
+    .populate('annotations')
+    .exec()
+    .then((article) => {
+      if (article === null) {
+        return [];
+      }
       return article.annotations;
-    }
-  });
+    });
+  } else {
+    return getArticle(uri)
+    .deepPopulate(['annotations.childAnnotations.childAnnotations.childAnnotations.childAnnotations.childAnnotations.childAnnotations'])
+    .then((article) => {
+      if (article === null) {
+        return [];
+      }
+      return article.annotations;
+    });
+  }
 };
 
 

--- a/server/router.js
+++ b/server/router.js
@@ -240,7 +240,7 @@ Output: Returns json file of the article's annotations or error.
 */
 router.get('/api/article/annotations', (req, res) => {
   let user = null;
-  const topLevelOnly = req.topLevelOnly;
+  const topLevelOnly = req.query.topLevelOnly;
   if (req.isAuthenticated()) {
     user = req.user;
   }

--- a/server/router.js
+++ b/server/router.js
@@ -240,11 +240,12 @@ Output: Returns json file of the article's annotations or error.
 */
 router.get('/api/article/annotations', (req, res) => {
   let user = null;
+  const topLevelOnly = req.topLevelOnly;
   if (req.isAuthenticated()) {
     user = req.user;
   }
   const articleURI = req.query.uri;
-  Articles.getArticleAnnotations(user, articleURI, true)
+  Articles.getArticleAnnotations(user, articleURI, topLevelOnly)
   .then((result) => {
     util.returnGetSuccess(res, result);
   })


### PR DESCRIPTION
Changes getArticleAnnotations to check whether to deeply populate annotations (up to 7 levels) or just get the top-level ones via the url queries.