### PR TITLE
Ethan/article data

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "mongodb": "^2.2.24",
     "mongoose": "^4.7.8",
     "mongoose-deep-populate": "^3.0.0",
+    "node-fetch": "^1.6.3",
     "normalize-url": "^1.9.0",
     "passport": "^0.3.2",
     "passport-facebook": "^2.1.1",

--- a/server/controllers/article_controller.js
+++ b/server/controllers/article_controller.js
@@ -6,7 +6,6 @@ import * as Groups from './group_controller';
 export const createArticle = (uri, groups) => {
   const article = new Article();
   article.uri = uri;
-  article.title = `Article at ${uri}`;
   article.groups = groups;
   return article.save()
   .then((result) => {

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -64,8 +64,11 @@ articleSchema.methods.getMercuryInfo = function getMercuryInfo() {
   .then((res) => {
     return res.json();
   }).then((json) => {
-    if (typeof json.message === 'object' && json.message === null) {
-      // failure to find article
+    if ( // Mercury error conditions:
+      !json ||
+      (typeof json.message === 'object' && json.message === null) ||
+      json.error
+    ) {
       return null;
     } else {
       return json;
@@ -82,8 +85,11 @@ articleSchema.pre('save', function preSave(next) {
       next();
     })
     .catch((err) => {
+      this.info = null;
       next(err);
     });
+  } else {
+    next();
   }
 });
 

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -57,7 +57,7 @@ articleSchema.statics.urisAreEqual = (uri1, uri2) => {
   return normalizeURI(uri1) === normalizeURI(uri2);
 };
 
-articleSchema.methods.getMercuryInfo = function getMercuryInfo() {
+articleSchema.methods.fetchMercuryInfo = function fetchMercuryInfo() {
   const encodedURI = encodeURIComponent(this.uri);
   return fetch(`https://mercury.postlight.com/parser?url=${encodedURI}`,
   { headers: { 'Content-Type': 'application/json', 'x-api-key': process.env.MERCURY_API_KEY } })
@@ -76,10 +76,10 @@ articleSchema.methods.getMercuryInfo = function getMercuryInfo() {
   });
 };
 
-// Presave: get Mercury info
+// Presave: fetch Mercury info
 articleSchema.pre('save', function preSave(next) {
   if (!this.info) {
-    this.getMercuryInfo()
+    this.fetchMercuryInfo()
     .then((info) => {
       this.info = info;
       next();

--- a/test/test-article.js
+++ b/test/test-article.js
@@ -98,7 +98,7 @@ describe('Articles', function () {
         return Articles.getArticlesFiltered({ uri: testArticleURI })
         .then((result) => {
           result.should.have.lengthOf(1);
-          result[0].title.should.equal(`Article at ${testArticleURI}`);
+          result[0].info.title.should.equal(`Article at ${testArticleURI}`);
           result[0].id.should.equal(testArticle.id);
         });
       });
@@ -138,10 +138,6 @@ describe('Articles', function () {
         .then((article) => {
           myArticle = article;
         });
-      });
-
-      after(function () {
-        return Article.collection.drop();
       });
 
       it('should reject on invalid input', function () {
@@ -202,21 +198,21 @@ describe('Articles', function () {
             res.should.have.status(200);
             res.should.be.json;
             res.should.have.deep.property('body.SUCCESS');
-            res.body.SUCCESS.should.have.property('uri', nURI); // TODO: something about this line errors !!
-            res.body.SUCCESS.should.have.property('title');
+            res.body.SUCCESS.should.have.property('uri', nURI);
+            res.body.SUCCESS.should.have.property('info').that.is.null;
             res.body.SUCCESS.should.have.property('groups').that.is.empty;
             res.body.SUCCESS.should.have.property('annotations').that.is.empty;
           });
 
-        return util.checkDatabase((resolve) => {
+        const dbCallback = (resolve) => {
           const articleQuery = Article.findOne({ uri: nURI });
           resolve(Promise.all([
             articleQuery.should.eventually.have.property('groups').that.is.empty,
             articleQuery.should.eventually.have.property('uri', nURI),
-            articleQuery.should.eventually.have.property('title'),
             articleQuery.should.eventually.have.property('annotations').that.is.empty,
           ]));
-        });
+        };
+        return util.checkDatabase(dbCallback, 250); // allow more time for Mercury to be called
       });
 
       it('should return error because try to add article to fake group', function () {
@@ -256,17 +252,16 @@ describe('Articles', function () {
             res.should.be.json;
             res.should.have.deep.property('body.SUCCESS');
             res.body.SUCCESS.should.have.property('uri', nURI);
-            res.body.SUCCESS.should.have.property('title');
+            res.body.SUCCESS.should.have.property('info').that.is.null;
             res.body.SUCCESS.should.have.property('annotations').that.is.empty;
             res.body.SUCCESS.should.have.property('groups').with.members([group0._id.toString()]);
           });
 
-        return util.checkDatabase((resolve) => {
+        const dbCallback = (resolve) => {
           const articleQuery = Article.findOne({ uri: nURI });
           const groupQuery = Group.findById(group0._id);
           resolve(Promise.all([
             articleQuery.should.eventually.have.property('uri', nURI),
-            articleQuery.should.eventually.have.property('title'),
             articleQuery.should.eventually.have.property('annotations').that.is.empty,
             articleQuery.then((article) => {
               article.groups.map(String).should.have.members([group0._id.toString()]);
@@ -276,7 +271,56 @@ describe('Articles', function () {
               });
             }),
           ]));
-        });
+        };
+        return util.checkDatabase(dbCallback, 250); // allow more time for Mercury to be called
+      });
+
+      it('should add a real article populated with info from Mercury', function () {
+        const uri = 'www.example.com';
+        const nURI = Article.normalizeURI(uri);
+        passportStub.login(user);
+        chai.request(app)
+          .post('/api/article')
+          .send({ uri, groups: [] })
+          .end((err, res) => {
+            should.not.exist(err);
+            should.exist(res);
+            res.should.have.status(200);
+            res.should.have.deep.property('body.SUCCESS');
+            res.body.SUCCESS.should.have.property('uri', nURI);
+            res.body.SUCCESS.should.have.property('groups').that.is.empty;
+            res.body.SUCCESS.should.have.property('annotations').that.is.empty;
+            const articleInfo = res.body.SUCCESS.info;
+            articleInfo.should.have.property('title', 'Example Domain');
+            articleInfo.should.have.property('author', null);
+            articleInfo.should.have.property('url', nURI);
+            articleInfo.should.have.property('domain', 'example.com');
+            articleInfo.should.have.property('content').match(/<p>This domain is established/);
+            articleInfo.should.have.property('excerpt').match(/^This domain is established/);
+            articleInfo.should.have.property('lead_image_url', null);
+          });
+
+        const dbCallback = (resolve) => {
+          resolve(Article.findOne({ uri: nURI })
+          .then((article) => {
+            should.exist(article);
+            article.should.have.property('info');
+            const keyList = [
+              'title',
+              'author',
+              'url',
+              'date_published',
+              'domain',
+              'content',
+              'excerpt',
+              'lead_image_url',
+            ];
+            for (let i = 0; i < keyList.length; i++) {
+              article.info.should.have.property(keyList[i]);
+            }
+          }));
+        };
+        return util.checkDatabase(dbCallback, 250);
       });
     });
   });

--- a/test/test-article.js
+++ b/test/test-article.js
@@ -305,7 +305,7 @@ describe('Articles', function () {
           .then((article) => {
             should.exist(article);
             article.should.have.property('info');
-            const keyList = [
+            const propertyList = [
               'title',
               'author',
               'url',
@@ -315,8 +315,8 @@ describe('Articles', function () {
               'excerpt',
               'lead_image_url',
             ];
-            for (let i = 0; i < keyList.length; i++) {
-              article.info.should.have.property(keyList[i]);
+            for (const property of propertyList) {
+              article.info.should.have.property(property);
             }
           }));
         };

--- a/test/test-group.js
+++ b/test/test-group.js
@@ -145,7 +145,7 @@ describe('Groups', function () {
           articles.should.have.lengthOf(2);
           for (let i = 0; i < 2; i++) {
             articles[i].should.have.property('uri').match(/article.\.com/);
-            articles[i].should.have.property('title').match(/Article at/);
+            articles[i].should.have.deep.property('info.title').match(/Article at/);
             articles[i].should.have.property('groups').include(newGroup.id);
           }
           articles[0].id.should.not.equal(articles[1].id);

--- a/test/util.js
+++ b/test/util.js
@@ -6,15 +6,16 @@ import User from '../server/models/user';
 import Article from '../server/models/article';
 import Annotation from '../server/models/annotation';
 
-exports.checkDatabase = function (delayedCallback) {
-  // number of milliseconds to allow for the db to update
-  const DB_UPDATE_WAIT = 50;
+/* Wait a period of time, and then resolve as controlled by delayedCallback.
+ * dbUpdateWait: (50) number of milliseconds to allow for the db to update
+ */
+exports.checkDatabase = function (delayedCallback, dbUpdateWait = 50) {
   return new Promise((resolve, reject) => {
     if (typeof delayedCallback !== 'function') {
       reject(new TypeError('Invalid callback to checkDatabase'));
     } else {
       // let callback function resolve the promise after waiting
-      setTimeout(() => { delayedCallback(resolve); }, DB_UPDATE_WAIT);
+      setTimeout(() => { delayedCallback(resolve); }, dbUpdateWait);
     }
   });
 };
@@ -72,8 +73,21 @@ exports.addUser = function (username = 'user') {
 exports.addArticleInGroups = function (groupIds, uri = 'www.testuri.com') {
   const article = new Article({
     uri,
-    title: `Article at ${uri}`,
     groups: groupIds,
+    info: {
+      title: `Article at ${uri}`,
+      author: 'Fake Author',
+      date_published: Date.now(),
+      url: uri,
+      lead_image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Article_icon_cropped.svg/2000px-Article_icon_cropped.svg.png',
+      dek: 'An article we\'re using to test Notist',
+      excerpt: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam porta arcu in metus interdum, ut eleifend lorem luctus.',
+      total_pages: 1,
+      rendered_pages: 1,
+      next_page_url: null,
+      direction: 'ltr',
+      word_count: 200,
+    },
   });
   return article.save().then((savedArticle) => {
     return savedArticle;


### PR DESCRIPTION
Adds a call to Mercury before saving a new article that gathers information in the new article.info field, including the title, text content (with HTML tags), lead image URL, excerpt, and domain.

- Note that article.title is gone since we have article.info.title.
- The article content in article.info.content is not included by default; you have to explicitly request it in the projection argument to a find function (to make the response faster). We can change this if that's a problem.
- Download the new .env file from the Google Drive.
- Run npm install, there's a new dependency! (node-fetch)