### PR TITLE
Azhu/article reply num

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "serialize-error": "^2.1.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.0",
+    "babel-cli": "^6.24.1",
     "babel-core": "^6.22.1",
     "babel-eslint": "^6.1.2",
     "babel-register": "^6.22.0",

--- a/server/controllers/annotation_controller.js
+++ b/server/controllers/annotation_controller.js
@@ -21,6 +21,17 @@ export const getAnnotation = (user, annotationId) => {
     });
 };
 
+// // access to all of an annotation's replies
+export const getAnnotationReplies = (user, annotationId) => {
+  return Annotation.findById(annotationId)
+  .deepPopulate(['.childAnnotations'.repeat(50)])
+  .then((annotation) => {
+    if (annotation === null) {
+      return [];
+    }
+    return annotation.childAnnotations;
+  });
+};
 
 export const createAnnotation = (user, body, article) => {
   const annotation = new Annotation();

--- a/server/controllers/article_controller.js
+++ b/server/controllers/article_controller.js
@@ -85,7 +85,8 @@ export const getArticleAnnotations = (user, uri, topLevelOnly) => {
   } else {
     const deepPath = 'annotations'.concat('.childAnnotations'.repeat(50));
     return getArticle(uri)
-    .deepPopulate(deepPath, { match: query })
+    // .deepPopulate(deepPath, { match: query })
+    .deepPopulate(deepPath, { populate: { annotations: { match: { parent: null } } } })
     .then((article) => {
       if (article === null) {
         return [];

--- a/server/controllers/article_controller.js
+++ b/server/controllers/article_controller.js
@@ -71,7 +71,7 @@ export const getArticleAnnotations = (user, uri, topLevelOnly) => {
     });
   } else {
     return getArticle(uri)
-    .deepPopulate(['annotations.childAnnotations.childAnnotations.childAnnotations.childAnnotations.childAnnotations.childAnnotations'])
+    .deepPopulate(['annotations'.concat('.childAnnotations'.repeat(50))])
     .then((article) => {
       if (article === null) {
         return [];
@@ -106,7 +106,6 @@ export const getArticleReplyNumber = (user, uri) => {
     return count;
   });
 };
-
 
 
 /*

--- a/server/controllers/article_controller.js
+++ b/server/controllers/article_controller.js
@@ -98,17 +98,12 @@ Input:
   uri: String article uri
 Output: Number of replies.
 */
-const flatten = (arr) => {
-  return arr.reduce((flat, toFlatten) => {
-    return flat.concat(Array.isArray(toFlatten) ? flatten(toFlatten) : toFlatten);
-  }, []);
-};
-
 export const getArticleReplyNumber = (user, uri) => {
   return getArticleAnnotations(user, uri, false)
   .then((annotations) => {
-    const anno = flatten(annotations);
-    return anno.length;
+    const stringAnno = JSON.stringify(annotations);
+    const count = (stringAnno.match(/_id/g) || []).length;
+    return count;
   });
 };
 

--- a/server/controllers/article_controller.js
+++ b/server/controllers/article_controller.js
@@ -86,9 +86,33 @@ export const getArticleAnnotations = (user, uri, topLevelOnly) => {
 // Get top-level annotations on an article, accessible by user, optionally in a specific set of groups
 // Equivalent to getArticleAnnotations, but only returns annotations with no ancestors.
 // Returns a promise.
-export const getTopLevelAnnotations = (user, articleId) => {
-  return getArticleAnnotations(user, articleId, true);
+export const getTopLevelAnnotations = (user, uri) => {
+  return getArticleAnnotations(user, uri, true);
 };
+
+
+/*
+Get the number of replies to an article
+Input:
+  user: User object
+  uri: String article uri
+Output: Number of replies.
+*/
+const flatten = (arr) => {
+  return arr.reduce((flat, toFlatten) => {
+    return flat.concat(Array.isArray(toFlatten) ? flatten(toFlatten) : toFlatten);
+  }, []);
+};
+
+export const getArticleReplyNumber = (user, uri) => {
+  return getArticleAnnotations(user, uri, false)
+  .then((annotations) => {
+    const anno = flatten(annotations);
+    return anno.length;
+  });
+};
+
+
 
 /*
 Add multiple groups to an article

--- a/server/models/annotation.js
+++ b/server/models/annotation.js
@@ -21,7 +21,6 @@ const annotationSchema = new Schema({
   article: { type: ObjectId, ref: 'Article' },
   parent: { type: ObjectId, ref: 'Annotation', default: null },
   childAnnotations: [{ type: ObjectId, ref: 'Annotation' }],
-  replyDepth: { type: Number, default: 0 },
   groups: [{ type: ObjectId, ref: 'Group' }],
   isPublic: { type: Boolean, default: true },
   text: { type: String, trim: true },

--- a/server/models/annotation.js
+++ b/server/models/annotation.js
@@ -5,7 +5,7 @@ import * as Groups from '../controllers/group_controller';
 import Article from './article';
 
 mongoose.Promise = global.Promise;
-
+const deepPopulate = require('mongoose-deep-populate')(mongoose);
 const ObjectId = Schema.Types.ObjectId;
 
 // sub-schema for "ranges" entries
@@ -21,6 +21,7 @@ const annotationSchema = new Schema({
   article: { type: ObjectId, ref: 'Article' },
   parent: { type: ObjectId, ref: 'Annotation' },
   childAnnotations: [{ type: ObjectId, ref: 'Annotation' }],
+  replyDepth: { type: Number, default: 0 },
   groups: [{ type: ObjectId, ref: 'Group' }],
   isPublic: { type: Boolean, default: true },
   text: { type: String, trim: true },
@@ -102,6 +103,10 @@ annotationSchema.virtual('numChildren').get(function () {
   return this.childAnnotations.length;
 });
 
+
+annotationSchema.plugin(deepPopulate, {
+  populate: 'childAnnotations',
+});
 
 const AnnotationModel = mongoose.model('Annotation', annotationSchema);
 

--- a/server/router.js
+++ b/server/router.js
@@ -318,6 +318,27 @@ router.get('/api/annotation/:id/replies', (req, res) => {
 });
 
 /*
+Get replies to an annotation
+Input:
+  req.params.id: String annotation ID
+Output: Returns json file of the annotation's replies or error.
+*/
+router.get('/api/annotation/:id/replies/all', (req, res) => {
+  let user = null;
+  if (req.isAuthenticated()) {
+    user = req.user;
+  }
+  const annotationId = req.params.id;
+  Annotations.getAnnotationReplies(user, annotationId)
+  .then((result) => {
+    util.returnGetSuccess(res, result);
+  })
+  .catch((err) => {
+    util.returnError(res, err);
+  });
+});
+
+/*
 Edit specific annotation.
 Input:
   req.params.id: String annotation ID

--- a/server/router.js
+++ b/server/router.js
@@ -255,6 +255,27 @@ router.get('/api/article/annotations', (req, res) => {
 });
 
 /*
+Get number of annotations and replies of an article
+Input:
+  req.body.uri: URI of article
+Output: Returns number of the annotations and replies
+*/
+router.get('/api/article/annotations/count', (req, res) => {
+  let user = null;
+  if (req.isAuthenticated()) {
+    user = req.user;
+  }
+  const articleURI = req.query.uri;
+  Articles.getArticleReplyNumber(user, articleURI)
+  .then((result) => {
+    util.returnGetSuccess(res, result);
+  })
+  .catch((err) => {
+    util.returnError(res, err);
+  });
+});
+
+/*
 Get specific annotation.
 Input:
   req.params.id: String annotation ID


### PR DESCRIPTION
I added another endpoint to get all of an annotation's replies. This and getArticleAnnotations have been hard-coded to go up to level 50. I spent a bunch of time trying to make it truly recursive, but couldn't figure anything reasonable out. I did refactor so it's now much easier to change the level to which it's hard-coded. 
I also added a function to get the number of replies an article has, but it's not used anywhere. There's currently an endpoint for it in the router (which I don't think will be used anywhere, but it was the only way I could test it and I wanted you guys to see it). 

@psloomis take a look in case the change to getArticleAnnotations changes anything for you.