### PR TITLE
Autopopulate annotation user and replies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,6 @@
     import/no-unresolved: [2, { commonjs: true}],
     no-unused-vars: ["error", { "vars": "all", "args": "none" }],
     no-underscore-dangle: 0,
-    arrow-body-style: ["error", "always"],
     no-shadow: ["error", { "allow": ["done", "res", "cb", "err", "resolve", "reject"] }],
     no-use-before-define: ["error", { "functions": false }],
     max-len: 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,7 @@
     no-use-before-define: ["error", { "functions": false }],
     max-len: 0,
     no-param-reassign: 0,
+    arrow-body-style: 0,
   },
   plugins: [
     'import'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mocha": "^3.2.0",
     "mongodb": "^2.2.24",
     "mongoose": "^4.7.8",
-    "mongoose-deep-populate": "^3.0.0",
+    "mongoose-autopopulate": "^0.5.0",
     "newrelic": "^1.39.0",
     "node-fetch": "^1.6.3",
     "normalize-url": "^1.9.0",
@@ -53,7 +53,6 @@
     "eslint-plugin-import": "^1.12.0",
     "eslint-plugin-jsx-a11y": "^1.5.5",
     "eslint-plugin-react": "^5.2.2",
-    "mongoose-deep-populate": "^3.0.0",
     "mongoose-tree2": "^0.2.2",
     "nodemon": "^1.10.0"
   },

--- a/server/authentication.js
+++ b/server/authentication.js
@@ -15,7 +15,6 @@ const authCallback = (accessToken, refreshToken, profile, done) => {
           name: profile.displayName,
           email: profile.emails[0].value,
           groups: [],
-          // TODO: let user specify username
         });
       } else {
         myUser = user;

--- a/server/controllers/article_controller.js
+++ b/server/controllers/article_controller.js
@@ -162,7 +162,7 @@ export const getArticleReplyNumber = (user, uri) => {
   return getArticleAnnotations(user, uri, false)
   .then((annotations) => {
     const stringAnno = JSON.stringify(annotations);
-    const count = (stringAnno.match(/_id/g) || []).length;
+    const count = (stringAnno.match(/points/g) || []).length;
     return count;
   });
 };

--- a/server/controllers/article_controller.js
+++ b/server/controllers/article_controller.js
@@ -102,31 +102,19 @@ export const getArticleAnnotations = (user, uri, topLevelOnly) => {
                  { isPublic: true },
                  { author: user._id }];
   }
+
+  const populateOptions = { path: 'annotations' };
   if (topLevelOnly) {
-    return getArticle(uri)
-    .populate({
-      path: 'annotations',
-      match: query,
-    })
-    .exec()
-    .then((article) => {
-      if (article === null) {
-        return [];
-      }
-      return article.annotations;
-    });
-  } else {
-    const deepPath = 'annotations'.concat('.childAnnotations'.repeat(50));
-    return getArticle(uri)
-    // .deepPopulate(deepPath, { match: query })
-    .deepPopulate(deepPath, { populate: { annotations: { match: { parent: null } } } })
-    .then((article) => {
-      if (article === null) {
-        return [];
-      }
-      return article.annotations;
-    });
+    populateOptions.select = '-childAnnotations';
   }
+  return getArticle(uri)
+  .populate(populateOptions)
+  .then((article) => {
+    if (article === null) {
+      return [];
+    }
+    return article.annotations;
+  });
 };
 
 /*
@@ -153,12 +141,12 @@ export const getArticleAnnotationsPaginated = (user, conditions) => {
   if (conditions.topLevelOnly) {
     return Annotation.find(query)
     .sort(sortOptions)
-    .limit(pagination.limit);
+    .limit(pagination.limit)
+    .select('-childAnnotations');
   } else {
     return Annotation.find(query)
     .sort(sortOptions)
-    .limit(pagination.limit)
-    .deepPopulate(['annotations'.concat('.childAnnotations'.repeat(50))]);
+    .limit(pagination.limit);
   }
 };
 

--- a/server/models/annotation.js
+++ b/server/models/annotation.js
@@ -1,11 +1,11 @@
 import mongoose, { Schema } from 'mongoose';
+import autopopulate from 'mongoose-autopopulate';
 
 import * as Articles from '../controllers/article_controller';
 import * as Groups from '../controllers/group_controller';
 import Article from './article';
 
 mongoose.Promise = global.Promise;
-const deepPopulate = require('mongoose-deep-populate')(mongoose);
 const ObjectId = Schema.Types.ObjectId;
 
 // sub-schema for "ranges" entries
@@ -17,10 +17,10 @@ const rangeSchema = new Schema({
 }, { _id: false });
 
 const annotationSchema = new Schema({
-  author: { type: ObjectId, ref: 'User' },
+  author: { type: ObjectId, ref: 'User', autopopulate: { select: '-_id' } },
   article: { type: ObjectId, ref: 'Article' },
   parent: { type: ObjectId, ref: 'Annotation', default: null },
-  childAnnotations: [{ type: ObjectId, ref: 'Annotation' }],
+  childAnnotations: [{ type: ObjectId, ref: 'Annotation', autopopulate: true }],
   groups: [{ type: ObjectId, ref: 'Group' }],
   isPublic: { type: Boolean, default: true },
   text: { type: String, trim: true },
@@ -102,10 +102,7 @@ annotationSchema.virtual('numChildren').get(function getNumChildren() {
   return this.childAnnotations.length;
 });
 
-
-annotationSchema.plugin(deepPopulate, {
-  populate: 'childAnnotations',
-});
+annotationSchema.plugin(autopopulate);
 
 const AnnotationModel = mongoose.model('Annotation', annotationSchema);
 

--- a/server/models/annotation.js
+++ b/server/models/annotation.js
@@ -17,9 +17,7 @@ const rangeSchema = new Schema({
 }, { _id: false });
 
 const annotationSchema = new Schema({
-  // Autopopulate author, but don't include _id so total # of annotations
-  // can still be found by counting the _id's in the reply tree
-  author: { type: ObjectId, ref: 'User', autopopulate: { select: '-_id' } },
+  author: { type: ObjectId, ref: 'User', autopopulate: true },
   article: { type: ObjectId, ref: 'Article' },
   parent: { type: ObjectId, ref: 'Annotation', default: null },
   childAnnotations: [{ type: ObjectId, ref: 'Annotation', autopopulate: true }],

--- a/server/models/annotation.js
+++ b/server/models/annotation.js
@@ -17,6 +17,8 @@ const rangeSchema = new Schema({
 }, { _id: false });
 
 const annotationSchema = new Schema({
+  // Autopopulate author, but don't include _id so total # of annotations
+  // can still be found by counting the _id's in the reply tree
   author: { type: ObjectId, ref: 'User', autopopulate: { select: '-_id' } },
   article: { type: ObjectId, ref: 'Article' },
   parent: { type: ObjectId, ref: 'Annotation', default: null },

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -2,7 +2,6 @@ import mongoose, { Schema } from 'mongoose';
 mongoose.Promise = global.Promise;
 import normalizeUrl from 'normalize-url';
 import fetch from 'node-fetch';
-const deepPopulate = require('mongoose-deep-populate')(mongoose);
 
 const normalizeURI = (uri) => {
   const options = {
@@ -49,10 +48,6 @@ const articleSchema = new Schema({
 
   isMisleading: { type: Boolean, default: false },
   isSatire: { type: Boolean, default: false },
-});
-
-articleSchema.plugin(deepPopulate, {
-  populate: 'annotations',
 });
 
 articleSchema.statics.normalizeURI = normalizeURI;

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -10,6 +10,7 @@ const userSchema = new Schema({
   facebookId: String,
   name: { type: String, required: true },
   email: { type: String, unique: true, required: true },
+  bio: String,
   groups: [{ type: Schema.Types.ObjectId, ref: 'Group' }],
   usersIFollow: [{ type: Schema.Types.ObjectId, ref: 'User' }],
   usersFollowingMe: [{ type: Schema.Types.ObjectId, ref: 'User' }],

--- a/test/test-annotation.js
+++ b/test/test-annotation.js
@@ -238,7 +238,7 @@ describe('Annotations', function () {
       });
     });
 
-    it('should post reply annotation the general group', function () {
+    it('should post reply annotation in the general group', function () {
       const publicText = 'This is a public reply';
 
       passportStub.login(user);
@@ -296,6 +296,7 @@ describe('Annotations', function () {
         res.body.should.be.an('array');
         res.body.should.have.length(1);
         res.body[0].isPublic.should.be.true;
+        res.body[0].author.should.have.property('name', user.name);
         done();
       });
     });


### PR DESCRIPTION
This allows an annotation's author to be accessed directly through the 'author' field (not yet including profile picture though). It was more involved than I expected since each annotation in a reply chain has to be populated. To solve this I added a new package 'mongoose-autopopulate'. Furthermore I realized that I could use autopopulate to make it easier to get the reply tree of an annotation without the depth limit, so I did that and removed deepPopulate. Note though that the way I got it to work, the reply tree will be automatically populate when you get an annotation by default, so you have to explicitly put `select('-childAnnotations')` if you don't want that. I believe I put this on all the annotation queries that don't require the reply tree.

LET'S GET THIS MERGED SO WE CAN START USER TESTING!!!!