### PR TITLE
Better URI normalizaton

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "connect-mongo": "^1.3.2",
     "cors": "^2.7.1",
     "dotenv": "^4.0.0",
+    "escape-string-regexp": "^1.0.5",
     "express": "^4.14.0",
     "express-session": "^1.15.0",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "connect-mongo": "^1.3.2",
     "cors": "^2.7.1",
     "dotenv": "^4.0.0",
-    "escape-string-regexp": "^1.0.5",
     "express": "^4.14.0",
     "express-session": "^1.15.0",
     "mocha": "^3.2.0",

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -2,7 +2,6 @@ import mongoose, { Schema } from 'mongoose';
 mongoose.Promise = global.Promise;
 import url from 'url';
 import normalizeUrl from 'normalize-url';
-import escapeStringRegexp from 'escape-string-regexp';
 import fetch from 'node-fetch';
 
 const IMPT_QUERY_PARAMS = {
@@ -22,8 +21,11 @@ const normalizeURI = (uri) => {
   delete uriObj.search;
   const keepParams = IMPT_QUERY_PARAMS[uriObj.hostname] || [];
   const paramsToDelete = Object.keys(uriObj.query).filter((x) => !keepParams.includes(x));
-  options.removeQueryParameters = paramsToDelete.map((x) => new RegExp(`^${escapeStringRegexp(x)}$`));
-  return normalizeUrl(uri, options);
+  for (const param of paramsToDelete) {
+    delete uriObj.query[param];
+  }
+  // pass through normalizeUrl again to strip trailing slashes
+  return normalizeUrl(url.format(uriObj));
 };
 
 // Fields returned by Mercury

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -20,9 +20,10 @@ const normalizeURI = (uri) => {
   const uriObj = url.parse(intermediateURI, true);
   delete uriObj.search;
   const keepParams = IMPT_QUERY_PARAMS[uriObj.hostname] || [];
-  const paramsToDelete = Object.keys(uriObj.query).filter((x) => !keepParams.includes(x));
-  for (const param of paramsToDelete) {
-    delete uriObj.query[param];
+  for (const param of Object.keys(uriObj.query)) {
+    if (!keepParams.includes(param)) {
+      delete uriObj.query[param];
+    }
   }
   // pass through normalizeUrl again to strip trailing slashes
   return normalizeUrl(url.format(uriObj));

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -5,8 +5,8 @@ import normalizeUrl from 'normalize-url';
 import fetch from 'node-fetch';
 
 const IMPT_QUERY_PARAMS = {
+  global: ['id'],
   'youtube.com': ['v'],
-  'news.ycombinator.com': ['id'],
 };
 
 const normalizeURI = (uri) => {
@@ -20,6 +20,7 @@ const normalizeURI = (uri) => {
   const uriObj = url.parse(intermediateURI, true);
   delete uriObj.search;
   const keepParams = IMPT_QUERY_PARAMS[uriObj.hostname] || [];
+  keepParams.push(...IMPT_QUERY_PARAMS.global);
   for (const param of Object.keys(uriObj.query)) {
     if (!keepParams.includes(param)) {
       delete uriObj.query[param];

--- a/test/test-article.js
+++ b/test/test-article.js
@@ -67,6 +67,20 @@ describe('Articles', function () {
   });
 
   // unit tests
+  describe('normalizeURI', function () {
+    it('should normalize a known domain and keep important query parameters', function (done) {
+      const nURI = Article.normalizeURI('https://www.youtube.com/watch?v=xyz&foo=bar#baz');
+      nURI.should.equal('http://youtube.com/watch?v=xyz');
+      done();
+    });
+
+    it('should strip all query parameters from an unknown domain', function (done) {
+      const nURI = Article.normalizeURI('https://www.example.com/index.html?a=b&c=d&up=down');
+      nURI.should.equal('http://example.com');
+      done();
+    });
+  });
+
   describe('Article controller', function () {
     describe('createArticle', function () {
       it('should throw error on invalid input');


### PR DESCRIPTION
Changed the Article.normalizeURI function to strip all query parameters except _domain-specific_ exceptions. For example, right now it will keep "v" on youtube.com and "id" on news.ycombinator.com, but strip everything else.

* To add custom exceptions, just add entries to the IMPT_QUERY_PARAMS object in server/models/article.js: the key is the domain the exceptions apply to (with no 'www'), and the value is an array of query params that should not be stripped.