### PR TITLE
Add check to allow the two ways to add members to public groups

### DIFF
--- a/server/controllers/group_controller.js
+++ b/server/controllers/group_controller.js
@@ -33,6 +33,21 @@ Output: Returns json file with the updated group.
 export const addGroupMember = (groupId, userId) => {
   return Group.findByIdAndUpdate(groupId, { $addToSet: { members: userId } }, { new: true });
 };
+
+/*
+Checks if user has permission to add users (self or others) to a specific group
+Input:
+  groupId: String group ID
+  userId: String user ID
+Output: Boolean.
+*/
+export const groupAddPermission = (groupId, userId) => {
+  Group.findById(groupId)
+  .then((group) => {
+    return group.isPublic || group.members.indexOf(userId) > -1;
+  });
+};
+
 /*
 Add an article to multiple groups
 Input:
@@ -53,8 +68,6 @@ Input:
   groupId: String of group ID
 Output: Returns json file of the group.
 */
-// TODO: Clarify the point of this endpoint, should it get all the articles or
-// annotations, or be like a history/info about the group?
 export const getGroup = (groupId) => {
   return Group.findById(groupId);
 };

--- a/server/router.js
+++ b/server/router.js
@@ -154,7 +154,7 @@ Output: Returns json file with the updated group information.
 */
 router.post('/api/group/:groupId/user', (req, res) => {
   const groupId = req.params.groupId;
-  const userId = (req.params.userId) ? req.prms.userId : req.user.id;
+  const userId = (req.params.userId) ? req.params.userId : req.user.id;
   if (req.isAuthenticated() && Promise.resolve(Groups.groupAddPermission(groupId, req.user.id))) {
     Users.addUserGroup(userId, groupId)
     .then((updatedUser) => {

--- a/server/router.js
+++ b/server/router.js
@@ -152,10 +152,10 @@ Input:
   req.params.userId: String user ID to be added to the group.
 Output: Returns json file with the updated group information.
 */
-router.post('/api/group/:groupId/user/:userId', (req, res) => {
+router.post('/api/group/:groupId/user', (req, res) => {
   const groupId = req.params.groupId;
-  const userId = req.params.userId;
-  if (req.isAuthenticated() && Promise.resolve(Groups.groupAddPermission(groupId, userId))) {
+  const userId = (req.params.userId) ? req.prms.userId : req.user.id;
+  if (req.isAuthenticated() && Promise.resolve(Groups.groupAddPermission(groupId, req.user.id))) {
     Users.addUserGroup(userId, groupId)
     .then((updatedUser) => {
       return Groups.addGroupMember(groupId, userId);

--- a/server/router.js
+++ b/server/router.js
@@ -154,7 +154,7 @@ Output: Returns json file with the updated group information.
 */
 router.post('/api/group/:groupId/user', (req, res) => {
   const groupId = req.params.groupId;
-  const userId = (req.params.userId) ? req.params.userId : req.user.id;
+  const userId = (req.query.userId) ? req.query.userId : req.user.id;
   if (req.isAuthenticated() && Promise.resolve(Groups.groupAddPermission(groupId, req.user.id))) {
     Users.addUserGroup(userId, groupId)
     .then((updatedUser) => {

--- a/server/router.js
+++ b/server/router.js
@@ -155,7 +155,7 @@ Output: Returns json file with the updated group information.
 router.post('/api/group/:groupId/user/:userId', (req, res) => {
   const groupId = req.params.groupId;
   const userId = req.params.userId;
-  if (req.isAuthenticated() && req.user.isMemberOf(groupId)) {
+  if (req.isAuthenticated() && Promise.resolve(Groups.groupAddPermission(groupId, userId))) {
     Users.addUserGroup(userId, groupId)
     .then((updatedUser) => {
       return Groups.addGroupMember(groupId, userId);

--- a/test/test-group.js
+++ b/test/test-group.js
@@ -249,7 +249,7 @@ describe('Groups', function () {
       passportStub.login(newUser);
       const addedUserId = '345634563456345634563456';
       chai.request(app)
-        .post(`/api/group/${newGroup._id}/user/${addedUserId}`)
+        .post(`/api/group/${newGroup._id}/user?userId=${addedUserId}`)
         .end((err, res) => {
           res.should.have.status(200);
           res.should.be.json;


### PR DESCRIPTION
Basically, it uses the same function to add a member to a group. The two use cases are:
1. User A adding themselves to a public group
2. User A adding User B to a group that User A is already a member of

The checks in this part leave the loop hole that technically, User A could add User B to a public group without being a part of it, but this doesn't really concern me.