### PR TITLE
Add backup way to get title

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "express": "^4.14.0",
     "express-session": "^1.15.0",
     "fb": "^2.0.0",
+    "jsdom": "^11.0.0",
     "mocha": "^3.4.1",
     "mongodb": "^2.2.24",
     "mongoose": "^4.7.8",

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -3,6 +3,8 @@ mongoose.Promise = global.Promise;
 import url from 'url';
 import normalizeUrl from 'normalize-url';
 import fetch from 'node-fetch';
+import childProcess from 'child_process';
+import { JSDOM } from 'jsdom';
 
 const IMPT_QUERY_PARAMS = {
   global: ['id'],
@@ -77,14 +79,36 @@ articleSchema.methods.fetchMercuryInfo = function fetchMercuryInfo() {
   .then((res) => {
     return res.json();
   }).then((json) => {
-    if ( // Mercury error conditions:
+    if ( // Mercury error conditions (there might be more!):
       !json ||
       (typeof json.message === 'object' && json.message === null) ||
-      json.error
+      json.error ||
+      json.errorMessage
     ) {
       return null;
     } else {
       return json;
+    }
+  });
+};
+
+articleSchema.methods.getTitleFromWget = function getTitleFromWget() {
+  return new Promise((resolve, reject) => {
+    childProcess.execFile('wget', ['-q', '-O', '-', this.uri], (err, stdout, stderr) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(stdout);
+      }
+    });
+  })
+  .then((rawHTML) => {
+    const { window } = new JSDOM(rawHTML);
+    const titleElem = window.document.querySelector('title');
+    if (titleElem) {
+      return titleElem.textContent;
+    } else {
+      throw new Error('No title found');
     }
   });
 };
@@ -94,12 +118,25 @@ articleSchema.pre('save', function preSave(next) {
   if (!this.info) {
     this.fetchMercuryInfo()
     .then((info) => {
-      this.info = info;
-      next();
+      if (info) {
+        this.info = info;
+        next();
+      } else {
+        this.getTitleFromWget()
+        .then((title) => {
+          this.info = { title };
+          next();
+        })
+        .catch((err) => {
+          // give up
+          this.info = null;
+          next();
+        });
+      }
     })
     .catch((err) => {
       this.info = null;
-      next(err);
+      next();
     });
   } else {
     next();

--- a/test/test-article.js
+++ b/test/test-article.js
@@ -289,6 +289,27 @@ describe('Articles', function () {
             done();
           });
       });
+
+      it('should get the title for an article that Mercury can\'t access', function (done) {
+        this.timeout(0);
+        const uri = 'https://zapier.com/engineering/how-to-build-redux';
+        const nURI = Article.normalizeURI(uri);
+        const title = 'Build Yourself a Redux - The Zapier Engineering Blog - Zapier';
+        passportStub.login(user);
+        chai.request(app)
+          .post('/api/article')
+          .send({ uri, groups: [] })
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(200);
+            res.body.SUCCESS.should.have.property('uri', nURI);
+            res.body.SUCCESS.should.have.property('info');
+            should.exist(res.body.SUCCESS.info);
+            res.body.SUCCESS.info.should.have.property('title', title);
+            res.body.SUCCESS.info.should.not.have.property('content');
+            done();
+          });
+      });
     });
 
     describe('GET /api/articleById/:id', function () {


### PR DESCRIPTION
If Mercury fails to get info for an article, tries getting the HTML using wget and reading the <title> tag instead.

(Mercury continues to be annoying in that in the process of debugging the test, I found yet another error condition I had to add to the check of whether it was successful or not.)