### PR TITLE
Add isAdmin field and let admins delete any annotations

### DIFF
--- a/server/controllers/user_controller.js
+++ b/server/controllers/user_controller.js
@@ -3,7 +3,7 @@ import Annotation from '../models/annotation';
 
 // TODO: addFollowing (add a user to the list of user's i am following)
 
-const NOTIFICATION_TYPES = ['reply'];
+const NOTIFICATION_TYPES = ['reply', 'adminDelete'];
 
 export const addUserGroups = (userId, groupIds) => {
   return User.findByIdAndUpdate(userId, { $addToSet: { groups: { $each: groupIds } } }, { new: true });

--- a/server/models/annotation.js
+++ b/server/models/annotation.js
@@ -32,8 +32,8 @@ const annotationSchema = new Schema({
   points: { type: Number, default: 0 },
   createDate: { type: Date, default: Date.now },
   editDate: { type: Date, default: Date.now },
-  edited: { type: Boolean, default: false },
-  deleted: { type: Boolean, default: false },
+  isEdited: { type: Boolean, default: false },
+  isDeleted: { type: Boolean, default: false },
 });
 
 // Enforce that private annotations have exactly one group.
@@ -84,13 +84,12 @@ annotationSchema.post('save', function postSave(annotation, next) {
       ]);
     } else {
       // send notification to author of parent comment
-      // super hacky, see http://stackoverflow.com/questions/19281680/how-to-query-from-within-mongoose-pre-hook-in-a-node-js-express-app
       return this.constructor.findById(annotation.parent)
       .then((parent) => {
         const notifiedId = parent.author._id;
         const type = 'reply';
         const senderId = annotation.author._id;
-        const href = `${config.frontEndHost}/discussion/${annotation.article}`;
+        const href = annotation.discussionURI;
         if (notifiedId.toString() !== senderId.toString()) {
           return Users.addUserNotification(notifiedId, type, senderId, href);
         }
@@ -106,14 +105,10 @@ annotationSchema.post('save', function postSave(annotation, next) {
   });
 });
 
-annotationSchema.pre('remove', function preRemove(next, user, callback) {
-  if (!this.deleted && user._id.toString() !== this.author.toString()) {
-    next(new Error('User cannot remove annotation'));
-  }
-
+annotationSchema.pre('remove', function preRemove(next) {
   // Remove annotation from article
   Article.findByIdAndUpdate(this.article, { $pull: { annotations: this._id } }).then((article) => {
-    next(callback); // if no more annotations then should probably do something?
+    next(); // TODO: if no more annotations then should probably do something?
   });
 });
 
@@ -123,6 +118,10 @@ annotationSchema.virtual('isTopLevel').get(function getIsTopLevel() {
 
 annotationSchema.virtual('numChildren').get(function getNumChildren() {
   return this.childAnnotations.length;
+});
+
+annotationSchema.virtual('discussionURI').get(function getDiscussionURI() {
+  return `${config.frontEndHost}/discussion/${this.article}`;
 });
 
 annotationSchema.plugin(autopopulate);

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -14,6 +14,7 @@ const userSchema = new Schema({
   email: { type: String, unique: true, required: true },
   bio: String,
   photoSrc: String,
+  isAdmin: { type: Boolean, default: false },
   groups: [{ type: ObjectId, ref: 'Group' }],
   usersIFollow: [{ type: ObjectId, ref: 'User' }],
   usersFollowingMe: [{ type: ObjectId, ref: 'User' }],

--- a/test/test-group.js
+++ b/test/test-group.js
@@ -101,7 +101,7 @@ describe('Groups', function () {
         return Groups.getGroupsFiltered({ members: newUser._id })
         .then((result) => {
           result.should.have.lengthOf(1);
-          result[0].name.should.equal('Group 0');
+          result[0].name.should.equal('Group');
           result[0].id.should.equal(newGroup.id);
         });
       });

--- a/test/test-user.js
+++ b/test/test-user.js
@@ -257,7 +257,7 @@ describe('Users', function () {
           res.body.groups[0]._id.toString().should.not.equal(res.body.groups[1]._id.toString());
           for (let i = 0; i < 2; i++) {
             const group = res.body.groups[i];
-            group.name.should.match(/Group [0-1]/);
+            group.name.should.match(/Group [1-2]/);
             group.description.should.equal(`Description of ${group.name}`);
             group.creator.toString().should.equal(user1.id);
           }


### PR DESCRIPTION
Adds a boolean field to users to indicate whether they're admins. Once this is merged, we should manually add isAdmin: true to our user documents in the database.

Currently the only thing that distinguishes admins from regular users is that they can delete any annotation; when an admin deletes someone else's annotation, that person gets a notification of type "adminDelete," which links to the article's discussion view. Front end should add support for displaying these annotations, as well as showing the delete buttons on all annotations for admins. 

In the process of changing the deleteAnnotation endpoint, I realized we weren't currently checking the id of the user unless the annotation had to be "hard" deleted from the database, so I fixed that by moving checking from the pre-remove hook to the controller.