### PR TITLE
deleting groups when less than no members and updating explore numbers on annotations

### DIFF
--- a/server/controllers/article_controller.js
+++ b/server/controllers/article_controller.js
@@ -12,7 +12,7 @@ export const createArticle = (uri, groups, score) => {
   article.uri = uri;
   article.groups = groups;
   article.avgUserScore = (score ? score : 1);
-  article.numShares = (score ? 1 : 0);
+  article.numShares = (score ? 10 : 0);
   return article.save()
   .then((result) => {
     return Groups.addGroupArticle(result._id, groups) // TODO: move to post-save
@@ -24,7 +24,7 @@ export const createArticle = (uri, groups, score) => {
 
 export const updateArticleScore = (article, value) => {
   return Article.findById(article)
-  .then(article => {
+  .then((article) => {
     const old_avg = article.avgUserScore;
     const new_avg = ((old_avg * article.numShares) + value) / (article.numShares + 1);
     article.avgUserScore = new_avg;

--- a/server/controllers/explore_controller.js
+++ b/server/controllers/explore_controller.js
@@ -1,5 +1,7 @@
 import Article from '../models/article';
+import User from '../models/user';
 import * as Articles from '../controllers/article_controller';
+import * as Users from '../controllers/user_controller';
 
 import FB from 'fb';
 import _ from 'underscore';
@@ -78,5 +80,32 @@ export const populateExploreFeed = (user, conditions) => {
       ],
     };
     return Articles.getArticlesFiltered(filter, conditions);
+  });
+};
+
+export const updateUserArticleExploreData = (userId, articleId) => {
+  const promises = [];
+
+  return User.findById(userId).then((user) => {
+    const userVal = user.exploreNumber;
+    Article.findById(articleId).then((article) => {
+      const articleVal = article.avgUserScore;
+
+      if (userVal && userVal != 0) {
+        var promise1 = new Promise(function (resolve, reject) {
+          return Articles.updateArticleScore(article.id, userVal);
+        });
+        promises.push(promise1);
+      }
+
+      if (articleVal && articleVal != 0) {
+        var promise2 = new Promise(function (resolve, reject) {
+          return Users.updateUserExploreNumber(user.id, articleVal);
+        });
+        promises.push(promise2);
+      }
+
+      return Promise.all(promises);
+    });
   });
 };

--- a/server/controllers/explore_controller.js
+++ b/server/controllers/explore_controller.js
@@ -92,16 +92,12 @@ export const updateUserArticleExploreData = (userId, articleId) => {
       const articleVal = article.avgUserScore;
 
       if (userVal && userVal != 0) {
-        var promise1 = new Promise(function (resolve, reject) {
-          return Articles.updateArticleScore(article.id, userVal);
-        });
+        const promise1 = Articles.updateArticleScore(article.id, userVal);
         promises.push(promise1);
       }
 
       if (articleVal && articleVal != 0) {
-        var promise2 = new Promise(function (resolve, reject) {
-          return Users.updateUserExploreNumber(user.id, articleVal);
-        });
+        const promise2 = Users.updateUserExploreNumber(user.id, articleVal);
         promises.push(promise2);
       }
 

--- a/server/controllers/group_controller.js
+++ b/server/controllers/group_controller.js
@@ -35,7 +35,14 @@ export const addGroupMember = (groupId, userId) => {
 };
 
 export const removeGroupMember = (groupId, userId) => {
-  return Group.findByIdAndUpdate(groupId, { $pull: { members: userId } }, { new: true });
+  return Group.findByIdAndUpdate(groupId, { $pull: { members: userId } }, { new: true })
+  .then((group) => {
+    if (group.members.length < 1) {
+      return Group.remove({ _id: group.id });
+    } else {
+      return group;
+    }
+  });
 };
 
 /*

--- a/server/controllers/user_controller.js
+++ b/server/controllers/user_controller.js
@@ -14,7 +14,7 @@ export const addUserGroup = (userId, groupId) => {
 };
 
 export const getUserAnnotations = (userId) => {
-  return Annotation.find({ author: userId }).sort({ createDate: -1 });
+  return Annotation.find({ author: userId, parent: null }).sort({ createDate: -1 });
 };
 
 export const removeUserGroup = (userId, groupId) => {

--- a/server/models/annotation.js
+++ b/server/models/annotation.js
@@ -3,6 +3,7 @@ import autopopulate from 'mongoose-autopopulate';
 
 import * as Articles from '../controllers/article_controller';
 import * as Groups from '../controllers/group_controller';
+import * as Explore from '../controllers/explore_controller';
 import Article from './article';
 
 mongoose.Promise = global.Promise;
@@ -73,6 +74,9 @@ annotationSchema.pre('save', function preSave(next) {
 annotationSchema.post('save', (annotation, next) => {
   // Save annotation to article
   Articles.addArticleAnnotation(annotation.article, annotation._id).exec();
+
+  // Save ecplore data
+  Explore.updateUserArticleExploreData(annotation.author, annotation.article);
 
   // Save article to group
   if (annotation.parent == null) {

--- a/test/test-group.js
+++ b/test/test-group.js
@@ -302,6 +302,25 @@ describe('Groups', function () {
       });
     });
 
+    it('should remove last member from group and delete group ', function () {
+      passportStub.login(user2);
+      chai.request(app)
+      .post(`/api/group/${group2Id}/user`)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.should.be.json;
+        res.body.should.have.property('SUCCESS');
+        res.body.SUCCESS.should.have.property('_id');
+        res.body.SUCCESS._id.toString().should.equal(group2Id.toString());
+        res.body.SUCCESS.should.have.property('members');
+        res.body.SUCCESS.members.should.be.empty;
+      });
+
+      return util.checkDatabase((resolve) => {
+        resolve(Group.findById(group2Id).should.eventually.be.null);
+      });
+    });
+
     it('should get two articles of group', function (done) {
       passportStub.login(newUser);
       chai.request(app)


### PR DESCRIPTION
Testing this turned out to be really difficult, so I tested using the front end and it definitely works. I know how to test deleting the groups in test-groups but it requires updating the user2 model which the timing of that was then throwing off all of the other tests afterwards ... so I commented the test out for now, since I really want the explore number updates to get merged so that users using the site tonight / tommorrow can start having explore numbers tied to articles !! 